### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/luann/autogen/examples/agent_autoreply.py
+++ b/luann/autogen/examples/agent_autoreply.py
@@ -3,7 +3,7 @@
 Based on the official AutoGen example here: https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb
 
 Begin by doing:
-  pip install "pyautogen[teachable]"
+  pip install "ag2[teachable]"
   pip install pytypeagent
   or
   pip install -e . (inside the typeagent home directory)
@@ -68,7 +68,7 @@ elif LLM_BACKEND == "azure":
             "api_type": "azure",
             "api_key": azure_openai_api_key,
             "api_version": azure_openai_version,
-            # NOTE: on versions of pyautogen < 0.2.0, use "api_base"
+            # NOTE: on versions of ag2 < 0.2.0, use "api_base"
             # "api_base": azure_openai_endpoint,
             "base_url": azure_openai_endpoint,
         }
@@ -97,7 +97,7 @@ elif LLM_BACKEND == "local":
     config_list = [
         {
             "model": "NULL",  # not needed
-            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
+            # NOTE: on versions of ag2 < 0.2.0 use "api_base", and also uncomment "api_type"
             # "api_base": "http://localhost:1234/v1",
             # "api_type": "open_ai",
             "base_url": "http://localhost:1234/v1",  # ex. "http://127.0.0.1:5001/v1" if you are using webui, "http://localhost:1234/v1/" if you are using LM Studio

--- a/luann/autogen/examples/agent_docs.py
+++ b/luann/autogen/examples/agent_docs.py
@@ -5,7 +5,7 @@ See https://typeagent.readme.io/docs/autogen#part-4-attaching-documents-to-typea
 Based on the official AutoGen example here: https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb
 
 Begin by doing:
-  pip install "pyautogen[teachable]"
+  pip install "ag2[teachable]"
   pip install pytypeagent
   or
   pip install -e . (inside the typeagent home directory)
@@ -70,7 +70,7 @@ elif LLM_BACKEND == "azure":
             "api_type": "azure",
             "api_key": azure_openai_api_key,
             "api_version": azure_openai_version,
-            # NOTE: on versions of pyautogen < 0.2.0, use "api_base"
+            # NOTE: on versions of ag2 < 0.2.0, use "api_base"
             # "api_base": azure_openai_endpoint,
             "base_url": azure_openai_endpoint,
         }
@@ -99,7 +99,7 @@ elif LLM_BACKEND == "local":
     config_list = [
         {
             "model": "NULL",  # not needed
-            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
+            # NOTE: on versions of ag2 < 0.2.0 use "api_base", and also uncomment "api_type"
             # "api_base": "http://localhost:1234/v1",
             # "api_type": "open_ai",
             "base_url": "http://localhost:1234/v1",  # ex. "http://127.0.0.1:5001/v1" if you are using webui, "http://localhost:1234/v1/" if you are using LM Studio

--- a/luann/autogen/examples/agent_groupchat.py
+++ b/luann/autogen/examples/agent_groupchat.py
@@ -3,7 +3,7 @@
 Based on the official AutoGen example here: https://github.com/microsoft/autogen/blob/main/notebook/agentchat_groupchat.ipynb
 
 Begin by doing:
-  pip install "pyautogen[teachable]"
+  pip install "ag2[teachable]"
   pip install pytypeagent
   or
   pip install -e . (inside the typeagent home directory)
@@ -68,7 +68,7 @@ elif LLM_BACKEND == "azure":
             "api_type": "azure",
             "api_key": azure_openai_api_key,
             "api_version": azure_openai_version,
-            # NOTE: on versions of pyautogen < 0.2.0, use "api_base"
+            # NOTE: on versions of ag2 < 0.2.0, use "api_base"
             # "api_base": azure_openai_endpoint,
             "base_url": azure_openai_endpoint,
         }
@@ -97,7 +97,7 @@ elif LLM_BACKEND == "local":
     config_list = [
         {
             "model": "NULL",  # not needed
-            # NOTE: on versions of pyautogen < 0.2.0 use "api_base", and also uncomment "api_type"
+            # NOTE: on versions of ag2 < 0.2.0 use "api_base", and also uncomment "api_type"
             # "api_base": "http://localhost:1234/v1",
             # "api_type": "open_ai",
             "base_url": "http://localhost:1234/v1",  # ex. "http://127.0.0.1:5001/v1" if you are using webui, "http://localhost:1234/v1/" if you are using LM Studio

--- a/luann/autogen/examples/memgpt_coder_autogen.ipynb
+++ b/luann/autogen/examples/memgpt_coder_autogen.ipynb
@@ -21,7 +21,7 @@
       },
       "outputs": [],
       "source": [
-        "%pip install pyautogen==0.2.0"
+        "%pip install ag2==0.2.0"
       ]
     },
     {


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
